### PR TITLE
Add run_steadycom strawman UI spec

### DIFF
--- a/ui/narrative/methods/run_steadycom/display.yaml
+++ b/ui/narrative/methods/run_steadycom/display.yaml
@@ -28,7 +28,7 @@ parameters :
             Fixed growth rate
         short-hint : |
             (optional) Fixed growth rate for the given model.
-    medium :
+    medium_upa :
         ui-name : |
             Growth medium
         short-hint : |

--- a/ui/narrative/methods/run_steadycom/display.yaml
+++ b/ui/narrative/methods/run_steadycom/display.yaml
@@ -1,0 +1,50 @@
+name: Run SteadyCom
+tooltip: |
+    Run SteadyCom
+screenshots: []
+
+icon:
+
+suggestions:
+    apps:
+        related:
+            []
+        next:
+            []
+    methods:
+        related:
+            []
+        next:
+            []
+
+parameters :
+    model_upa :
+        ui-name : |
+            An FBA Model
+        short-hint : |
+            A file input for testing.
+    fixed_gr :
+        ui-name : |
+            Fixed growth rate
+        short-hint : |
+            (optional) Fixed growth rate for the given model.
+    medium :
+        ui-name : |
+            Growth medium
+        short-hint : |
+            (optional) The medium for growing the set of models.
+    flux_output :
+        ui-name : |
+            SteadyCom Output
+        short-hint : |
+            The output from SteadyCom, represented as a set of fluxes and optimal community growth rate
+
+parameter-groups :
+    model_inputs:
+        ui-name : |
+            Model Information
+        short-hint : |
+            A list of models with their (optional) maximum growth rates
+description : |
+    <p>Calculate maximum growth rate, fluxes, and pareto optimality for a set of FBA models growing
+    under some medium condition.</p>

--- a/ui/narrative/methods/run_steadycom/spec.json
+++ b/ui/narrative/methods/run_steadycom/spec.json
@@ -1,0 +1,108 @@
+{
+    "ver": "0.0.1",
+    "authors": [
+        "wjriehl"
+    ],
+    "contact": "https://www.kbase.us/contact-us",
+    "visible": true,
+    "categories": ["active", "metabolic modeling"],
+    "widgets": {
+        "input": null,
+        "output": null
+    },
+    "parameters": [
+        {
+            "id": "model_upa",
+            "optional": false,
+            "advanced": false,
+            "allow_multiple": false,
+            "default_values": [ "" ],
+            "field_type": "text",
+            "text_options": {
+                "valid_ws_types": ["KBaseFBA.FBAModel"]
+            }
+        },
+        {
+            "id": "fixed_gr",
+            "optional": true,
+            "advanced": true,
+            "allow_multiple": false,
+            "field_type": "text",
+            "text_options": {
+                "validate_as": "float",
+                "max_float": 1
+            }
+        },
+        {
+            "id": "medium",
+            "optional": true,
+            "advanced": false,
+            "allow_multiple": false,
+            "default_values": [ "" ],
+            "field_type": "text",
+            "text_options": {
+                "valid_ws_types": ["KBaseBiochem.Media"]
+            }
+        },
+        {
+            "id": "flux_output",
+            "optional": false,
+            "advanced": false,
+            "allow_multiple": false,
+            "field_type": "text",
+            "text_options": {
+                "valid_ws_types": ["KBaseFBA.FBA"],
+                "is_output_name": true
+            }
+        }
+    ],
+    "parameter-groups": [
+        {
+            "id": "model_inputs",
+            "optional": false,
+            "allow_multiple": true,
+            "parameters": ["model_upa", "fixed_gr"],
+            "with_border": true
+        }
+    ],
+    "behavior": {
+        "service-mapping": {
+            "url": "",
+            "name": "MaranasTools",
+            "method": "run_steadycom",
+            "input_mapping": [
+                {
+                    "input_parameter": "model_inputs",
+                    "target_property": "model_inputs"
+                },
+                {
+                    "input_parameter": "medium",
+                    "target_property": "medium"
+                },
+                {
+                    "narrative_system_variable": "workspace_name",
+                    "target_property": "workspace_name"
+                },
+                {
+                    "input_parameter": "flux_output",
+                    "target_property": "flux_output"
+                }
+            ],
+            "output_mapping": [
+                {
+                    "service_method_output_path": [0,"report_name"],
+                    "target_property": "report_name"
+                },
+                {
+                    "service_method_output_path": [0,"report_ref"],
+                    "target_property": "report_ref"
+                },
+                {
+                    "service_method_output_path": [0,"flux_output"],
+                    "target_property": "out_value"
+                }
+            ]
+        }
+    },
+    "job_id_output_field": "docker"
+}

--- a/ui/narrative/methods/run_steadycom/spec.json
+++ b/ui/narrative/methods/run_steadycom/spec.json
@@ -34,7 +34,7 @@
             }
         },
         {
-            "id": "medium",
+            "id": "medium_upa",
             "optional": true,
             "advanced": false,
             "allow_multiple": false,
@@ -76,8 +76,8 @@
                     "target_property": "model_inputs"
                 },
                 {
-                    "input_parameter": "medium",
-                    "target_property": "medium"
+                    "input_parameter": "medium_upa",
+                    "target_property": "medium_upa"
                 },
                 {
                     "narrative_system_variable": "workspace_name",
@@ -99,7 +99,7 @@
                 },
                 {
                     "service_method_output_path": [0,"flux_output"],
-                    "target_property": "out_value"
+                    "target_property": "flux_output"
                 }
             ]
         }


### PR DESCRIPTION
A first pass at a UI for the SteadyCom app. Includes:
* lists of pairs of FBA models with (optional) fixed growth rate
* an output object as a KBase FBA result, which I think would work best at first
* an optional medium object. It's possible to just use "rich" medium as well (e.g., everything allowed at maximum) but we can change this to required if necessary

As given here, these inputs map into a spec that would look like (as discussed with Lin):
```
typedef structure {
    string model_upa;
    float fixed_gr;
} ModelInput;

typedef structure {
    list<ModelInput> model_inputs;
    string medium_upa;
    string flux_output;
    string workspace_name;
} SteadyComParams;

typedef structure {
    string report_name;
    string report_ref;
    string flux_output;
} SteadyComOutput;

funcdef run_steadycom(SteadyComParams params) returns (SteadyComOutput) authorization required;
```
    