### PR TITLE
changed category spelling

### DIFF
--- a/ui/narrative/methods/run_steadycom/spec.json
+++ b/ui/narrative/methods/run_steadycom/spec.json
@@ -5,7 +5,7 @@
     ],
     "contact": "https://www.kbase.us/contact-us",
     "visible": true,
-    "categories": ["active", "metabolic modeling"],
+    "categories": ["active", "metabolic_modeling"],
     "widgets": {
         "input": null,
         "output": null


### PR DESCRIPTION
The standard category name that's more widely used is "metabolic_modeling", with an underscore.

The version here with the space would map to the same display name ("Metabolic Modeling"), but since it was keyed differently, ("metabolic modeling" vs "metabolic_modeling"), you'd end up with a duplicated category.

I'm going to adjust the front end code to ensure it compensates for these issues, but I figured we should standardize the spec as well.